### PR TITLE
Fix card dnd issue

### DIFF
--- a/src/components/board/columns/card.tsx
+++ b/src/components/board/columns/card.tsx
@@ -11,7 +11,8 @@ type Props = {
 
 const Card: FC<Props> = ({ cardIndex, showCardDetail, card }) => {
   return (
-    <Draggable draggableId={card._id} index={cardIndex}>
+    // https://github.com/atlassian/react-beautiful-dnd/issues/1767
+    <Draggable draggableId={card._id} index={cardIndex} key={card._id}>
       {(provided) => (
         <Box
           {...provided.draggableProps}


### PR DESCRIPTION
**Description : -**

The mood of this PR 😎 : -

![rocket](https://user-images.githubusercontent.com/44323532/120934884-cb140d00-c71d-11eb-8ed8-4dcaf02b5dad.gif)

This PR fixes the card dnd issue. When the card gets dragged to any location then either prev or next cards lost the draggable property. This is because there was no key mapped to each item. Using index was not working but using id as key worked perfectly fine.

Github Issue - https://github.com/atlassian/react-beautiful-dnd/issues/1767