### PR TITLE
Fix delay or glitch once card gets moved

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "js-cookie": "^2.2.1",
     "jsonwebtoken": "^8.5.1",
     "lodash.debounce": "^4.0.8",
+    "lodash.findindex": "^4.6.0",
     "mongodb": "^3.6.6",
     "next": "^10.1.3",
     "react": "^17.0.2",

--- a/src/slices/cards.ts
+++ b/src/slices/cards.ts
@@ -5,6 +5,7 @@ import { CardSlice } from '@/src/types/cards';
 
 import { BoardSlice } from '@/src/types/boards';
 import shortId from 'shortid';
+import findIndex from 'lodash.findindex';
 
 type CardPatch = {
   _id: string;
@@ -176,9 +177,11 @@ export const cardsSlice = createSlice({
   initialState: initialState,
   reducers: {
     resetCards: () => initialState,
-    updateCardData: (state, { payload }) => {
-      const card = state.cards.filter((card) => card._id === payload.cardId);
-      // state.cards[] =
+    updateCardSequenceToLocalState: (state, { payload }) => {
+      const cardIndex = findIndex(state.cards, { _id: payload._id });
+
+      state.cards[cardIndex].sequence = payload.sequence;
+      state.cards[cardIndex].columnId = payload.columnId;
     }
   },
   extraReducers: {
@@ -231,6 +234,6 @@ export const cardsSlice = createSlice({
   }
 });
 
-export const { resetCards } = cardsSlice.actions;
+export const { resetCards, updateCardSequenceToLocalState } = cardsSlice.actions;
 
 export default cardsSlice.reducer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,6 +2881,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.findindex@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.findindex/-/lodash.findindex-4.6.0.tgz#a3245dee61fb9b6e0624b535125624bb69c11106"
+  integrity sha1-oyRd7mH7m24GJLU1ElYku2nBEQY=
+
 lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"


### PR DESCRIPTION
**Issue Description : -**

When a card is moved then it gets back to its original position for a second or 2 and then again moves to the final position. This is because the card is saved and fetched again. Doing this API call takes time to complete.

Now we are just saving the card sequence and not fetching again. To update the local state we are calling another action to update the card sequence.