### PR TITLE
Fix card drop on column with no cards

### DIFF
--- a/src/components/board/columns/column.tsx
+++ b/src/components/board/columns/column.tsx
@@ -84,7 +84,8 @@ const Column = ({ showCardDetail, column, index, id, cards }): JSX.Element => {
         </Box>
         <Droppable droppableId={column._id}>
           {(provided) => (
-            <Box ref={provided.innerRef} {...provided.droppableProps}>
+            // 2px height is needed to make the drop work when there is no card.
+            <Box ref={provided.innerRef} {...provided.droppableProps} minHeight="2px">
               <Cards showCardDetail={showCardDetail} cards={cardsInSortedSequence} />
               {provided.placeholder}
             </Box>


### PR DESCRIPTION
**Description : -**

When s new column is added and when you move a card to it then it does not work. This is because the height of the droppable area is 0 and the drop could not detect it.

Adding a 2px of height fixes the issue.